### PR TITLE
Matching markdown package with meinhof base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/yaml":             	"2.2.*",        
         "twig/twig":                	"1.12.*",
         "kriswallsmith/assetic":    	"1.1.*",
-        "dflydev/markdown":         	"1.0.*",
+        "michelf/php-markdown":         "1.4.*",
         "symfony/translation":          "2.2.*"
     },
     "scripts": {


### PR DESCRIPTION
Hi, first of all, thanks for this great program!

I updated the markdown version on the standard distribution to match the current base repo. I also saw that you are using '2.5.*' Symfony components versions, I don't know if it should be updated here in the standard distribution or not. Maybe after passing some tests!
